### PR TITLE
Fixed a wrong explanation of conditional(ternary) operator

### DIFF
--- a/Video 56/index.js
+++ b/Video 56/index.js
@@ -45,7 +45,7 @@ if(a>b){
     let c = a - b;
 }
 else {
-    let c = a - b;
+    let c = b - a;
 }
 
 */


### PR DESCRIPTION
This pull request fixes the wrong explanation in the working of conditional(ternary) operator. Under "transtales to", in if-else part, it will be "let c= b - a;" in the 'else' part.