### PR TITLE
Fixes Todo-List Local Storage Issue (fixes #205)

### DIFF
--- a/Video 114/src/App.jsx
+++ b/Video 114/src/App.jsx
@@ -23,7 +23,7 @@ function App() {
   }
 
   //instead of applying SaveToLS everywhere, this constantly checks for changes in "todos".
-  // This ensures that the todo-list is always kept updated
+  // This ensures that the todo-list is always kept updated 
   useEffect(() => {
     localStorage.setItem("todos", JSON.stringify(todos))
   }, [todos])

--- a/Video 114/src/App.jsx
+++ b/Video 114/src/App.jsx
@@ -7,21 +7,27 @@ import { v4 as uuidv4 } from 'uuid';
 function App() { 
 
   const [todo, setTodo] = useState("")
-  const [todos, setTodos] = useState([])
+  const [todos, setTodos] = useState(GetTodos)
   const [showFinished, setshowFinished] = useState(true)
 
-  useEffect(() => {
+  //This initialises todos and makes sure that useEffect() for todos is not disrupted due to previous method of initialization
+  function GetTodos(){
     let todoString = localStorage.getItem("todos")
     if(todoString){
       let todos = JSON.parse(localStorage.getItem("todos")) 
-      setTodos(todos)
+      return todos;
     }
-  }, [])
-  
-
-  const saveToLS = (params) => {
-    localStorage.setItem("todos", JSON.stringify(todos))
+    else{
+      return [];
+    }
   }
+
+  //instead of applying SaveToLS everywhere, this constantly checks for changes in "todos".
+  // This ensures that the todo-list is always kept updated
+  useEffect(() => {
+    localStorage.setItem("todos", JSON.stringify(todos))
+  }, [todos])
+
 
   const toggleFinished = (e) => {
     setshowFinished(!showFinished)
@@ -37,7 +43,7 @@ function App() {
       return item.id!==id
     }); 
     setTodos(newTodos) 
-    saveToLS()
+    // saveToLS()
   }
 
   const handleDelete= (e, id)=>{  
@@ -45,13 +51,13 @@ function App() {
       return item.id!==id
     }); 
     setTodos(newTodos) 
-    saveToLS()
+    // saveToLS()
   }
 
   const handleAdd= ()=>{
     setTodos([...todos, {id: uuidv4(), todo, isCompleted: false}])
     setTodo("") 
-    saveToLS()
+    // saveToLS()
   }
   
   const handleChange= (e)=>{ 
@@ -66,7 +72,7 @@ function App() {
     let newTodos = [...todos];
     newTodos[index].isCompleted = !newTodos[index].isCompleted;
     setTodos(newTodos)
-    saveToLS()
+    // saveToLS()
   }
   
 


### PR DESCRIPTION
The function saveToLS was getting executed properly due to the **asynchronous nature of useState()** function. This was fixed by **initializing the Todo List** (todos) **using a function called GetTodos()**. Initializing with a seperate function ensures 2 things:

1) The useEffect function used later on; which tracks todos, does not get interfered by todos getting initialized with the help of settodos(). This ensures that the local storage during initialization remains intact while also always listening to any changes made in todos after initialization. Hence, the fetching from local storage remains the same, but made in a different way.
2) This enables the use of useEffect() on todos, and removes the need to add "saveToLS()" everywhere the list changes. This also keeps track of todo_list LIVE, instead of some change/function triggering saveToLS() directly/indirectly. 